### PR TITLE
prevent hook on loading native library

### DIFF
--- a/app/src/main/c/native-lib.c
+++ b/app/src/main/c/native-lib.c
@@ -11,6 +11,8 @@ static inline bool is_supath_detected();
 
 static const char *TAG = "DetectMagiskNative";
 
+static int hookDetect = 1;
+
 static char *blacklistedMountPaths[] = {
         "/sbin/.magisk/",
         "/sbin/.core/mirror",
@@ -34,6 +36,16 @@ static const char *suPaths[] = {
         "/data/su",
         "/dev/su"
 };
+
+JNIEXPORT jboolean
+Java_com_darvin_security_Native_isNativeLibLoaded(JNIEnv
+* env, jclass clazz, jboolean debug) {
+    if(debug){
+        hookDetect = 1;
+    }else{
+        hookDetect = 0;
+    }
+}
 
 
 JNIEXPORT jboolean

--- a/app/src/main/java/com/darvin/security/IsolatedService.java
+++ b/app/src/main/java/com/darvin/security/IsolatedService.java
@@ -23,6 +23,12 @@ public class IsolatedService extends Service{
 
     private final IIsolatedService.Stub mBinder = new IIsolatedService.Stub(){
         public boolean isMagiskPresent(){
+            try{
+                Native.isNativeLibLoaded(true);
+            }catch (UnsatisfiedLinkError e){
+                Log.i(TAG, "Native lib fails to load.");
+                return true;
+            }
 
             Log.d(TAG, "Isolated UID:"+ Os.getuid());
 
@@ -61,8 +67,6 @@ public class IsolatedService extends Service{
                     isMagiskPresent = Native.isMagiskPresentNative();
                     Log.d(TAG, "Found Magisk in Native " + isMagiskPresent);
                 }
-
-
 
             } catch (IOException e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/darvin/security/Native.java
+++ b/app/src/main/java/com/darvin/security/Native.java
@@ -7,5 +7,5 @@ class Native {
     }
 
     static native boolean isMagiskPresentNative();
-
+    static native boolean isNativeLibLoaded(boolean debug);
 }


### PR DESCRIPTION
Hi darvin. I'm developing root detection for thesis recently. Your work is pretty great!
To make it more resistant to Xposed hook, I add some examination for library loading in case System.loadLibrary function is directly hooked. 